### PR TITLE
공지, 일기 가이드에 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,10 @@ dependencies {
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	runtimeOnly 'com.h2database:h2'
 
+	// cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 	// S3
 	implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.1000')
 	implementation 'com.amazonaws:aws-java-sdk-s3'

--- a/src/main/java/com/meommu/meommuapi/core/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/meommu/meommuapi/core/auth/service/AuthServiceImpl.java
@@ -45,36 +45,23 @@ public class AuthServiceImpl implements AuthService{
 		String accessToken = jwtTokenProvider.createAccessToken(kindergarten.getId());
 		String refreshToken = jwtTokenProvider.createRefreshToken(kindergarten.getId());
 		Long expiration = jwtTokenProvider.getExpiration(refreshToken);
-
 		refreshTokenRepository.save(kindergarten.getId(), refreshToken, expiration);
-
 		return TokenResponse.from(accessToken, refreshToken);
 	}
 
 	@Override
 	@Transactional
 	public TokenResponse reissue(AuthInfo authInfo, ReissueRequest request) {
-		// 1. Refresh Token 검증
 		jwtTokenProvider.validateRefreshToken(request.getRefreshToken());
-
-		// 2. 인증정보
 		Long id = authInfo.getId();
-
-		// 3. Redis RefreshToken 조회
 		String refreshToken = refreshTokenRepository.findByUserId(id);
 		if (!refreshToken.equals(request.getRefreshToken())) {
 			throw new JwtException(MALFORMED_JWT);
 		}
-
-		// 3. 새로운 토큰 발급
 		String newAccessToken = jwtTokenProvider.createAccessToken(id);
 		String newRefreshToken = jwtTokenProvider.createRefreshToken(id);
-
-		// 4. Redis RefreshToken 업데이트
 		Long expiration = jwtTokenProvider.getExpiration(refreshToken);
 		refreshTokenRepository.save(id, newRefreshToken, expiration);
-
-		// 5. 토큰 반환
 		return TokenResponse.from(newAccessToken, newRefreshToken);
 	}
 

--- a/src/main/java/com/meommu/meommuapi/core/guide/service/GuideServiceImpl.java
+++ b/src/main/java/com/meommu/meommuapi/core/guide/service/GuideServiceImpl.java
@@ -2,6 +2,8 @@ package com.meommu.meommuapi.core.guide.service;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,11 +35,13 @@ public class GuideServiceImpl implements GuideService {
 	}
 
 	@Override
+	@Cacheable(cacheNames = "gpt_guide")
 	public GuideResponses findGuides() {
 		return GuideResponses.from(guideRepository.findAll());
 	}
 
 	@Override
+	@Cacheable(cacheNames = "gpt_guide_detail")
 	public GuideDetailResponses findGuideDetails(Long guideId) {
 		List<GuideDetail> guideDetails = guideDetailRepository.findAllByGuideId(guideId);
 		return GuideDetailResponses.from(guideDetails);
@@ -45,6 +49,7 @@ public class GuideServiceImpl implements GuideService {
 
 	@Override
 	@Transactional
+	@CacheEvict(cacheNames = "gpt_guide_detail")
 	public GuideDetailSaveResponse createGuideDetail(
 		Long guideId,
 		GuideDetailSaveRequest guideDetailSaveRequest
@@ -57,6 +62,7 @@ public class GuideServiceImpl implements GuideService {
 
 	@Override
 	@Transactional
+	@CacheEvict(cacheNames = "gpt_guide_detail")
 	public void deleteGuideDetail(Long guideId, Long detailId) {
 		Guide guide = getGuideById(guideId);
 		GuideDetail guideDetail = getGuideDetailById(detailId);

--- a/src/main/java/com/meommu/meommuapi/core/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/com/meommu/meommuapi/core/notice/service/NoticeServiceImpl.java
@@ -2,6 +2,7 @@ package com.meommu.meommuapi.core.notice.service;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +21,9 @@ public class NoticeServiceImpl implements NoticeService{
 	}
 
 	@Override
+	// @Cacheable(cacheNames = "notice")
 	public NoticeResponses findNotices() {
+		System.out.println("캐시 이용 전");
 		List<Notice> notices = noticeRepository.findAllByOrderByCreatedAtDesc();
 		return NoticeResponses.from(notices);
 	}

--- a/src/main/java/com/meommu/meommuapi/global/cache/CacheConfig.java
+++ b/src/main/java/com/meommu/meommuapi/global/cache/CacheConfig.java
@@ -1,0 +1,37 @@
+package com.meommu.meommuapi.global.cache;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+	@Bean
+	public List<CaffeineCache> caffeineCaches() {
+		return Arrays.stream(CacheType.values())
+			.map(cache -> new CaffeineCache(cache.getCacheName(),
+				Caffeine.newBuilder().recordStats()
+					.expireAfterWrite(cache.getExpiredAfterWrite(), TimeUnit.SECONDS)
+					.maximumSize(cache.getMaximumSize())
+					.build()))
+			.toList();
+	}
+
+	@Bean
+	public CacheManager cacheManager(List<CaffeineCache> caffeineCaches) {
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		cacheManager.setCaches(caffeineCaches);
+		return cacheManager;
+	}
+}

--- a/src/main/java/com/meommu/meommuapi/global/cache/CacheType.java
+++ b/src/main/java/com/meommu/meommuapi/global/cache/CacheType.java
@@ -1,0 +1,32 @@
+package com.meommu.meommuapi.global.cache;
+
+public enum CacheType {
+
+	NOTICE("notice", 60 * 60, 10000),
+
+	GPT_GUIDE("gpt_guide", 60 * 60, 10000),
+
+	GPT_GUIDE_DETAIL("gpt_guide_detail", 60 * 60, 10000);
+
+	private final String cacheName;
+	private final int expiredAfterWrite;
+	private final int maximumSize;
+
+	CacheType(String cacheName, int expiredAfterWrite, int maximumSize) {
+		this.cacheName = cacheName;
+		this.expiredAfterWrite = expiredAfterWrite;
+		this.maximumSize = maximumSize;
+	}
+
+	public String getCacheName() {
+		return cacheName;
+	}
+
+	public int getExpiredAfterWrite() {
+		return expiredAfterWrite;
+	}
+
+	public int getMaximumSize() {
+		return maximumSize;
+	}
+}


### PR DESCRIPTION
### 💁‍♂️ PR 개요
- #59 에 명시된 기능 구현했습니다.
<br/>   

### 📝 변경 사항
- Ehcache3를 적용하려고 했으나 FactoryBean 의존성을 찾아오지 못하는 문제가 발생하여 Caffeine으로 변경했습니다.
- 캐시 적용 후 nGrinder로 공지사항 API에 부하 테스트를 진행했습니다.
  - `수치 변화`
    - 평균 TPS :  { 5800 } → { 12800 }  **약 2배 개선**
    - Peek TPS :  { 7000 } → { 14800 }
    - Mean Test Time : { 1.59 } ms → { 0.7 } ms **약 2배 단축**
    - Exected Tests : {  340000  } → { 750000  }  **약 2배 실행**
  - `지표 변화`
    - 요청이 더 많아져서 GC가 더 많이 발생
    - 그만큼 Heap 영역도 많이 사용

<br/>

### 📷 스크린 샷 (선택)
![image](https://github.com/meommu/meommu-BE/assets/97517890/2dc5fdd1-0562-4041-b1c5-a29f60a82a70)
- 빨간 박스 : 캐시 적용 후
- 파란 박스 : 캐시 적용 전
<br/>

### 🗣 리뷰어한테 할 말 (선택)
- 
<br/>

### 🧪 테스트 범위 (선택)
- nGrinder로 부하테스트 후 Scouter로 모니터링
<br/> 
